### PR TITLE
Deployer update with Verification Tests and Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,16 +36,16 @@ To work with this deployment bundle, a developer requires use of the `mpdev` dev
 ```
 The top level of this package has three items: this README, vendored marketplace-tools, and the op-scim-bridge GCP package.
 
-The op-scim-bridge package is fruther broken down into five components:
+The op-scim-bridge package is further broken down into five components:
 - apptest -> Instructions for building the verification test image
-- chart -> The main chart (kubernetes package) for building and running the SCIM Bridge. More information can be found in [op-scim-bridge/chart/op-scim/README.md](./op-scim-bridge/chart/op-scim/README.md)
+- chart -> The main chart (Kubernetes package) for building and running the SCIM Bridge. More information can be found in [op-scim-bridge/chart/op-scim/README.md](./op-scim-bridge/chart/op-scim/README.md)
 - deployer -> The GCP deployer which creates and runs the chart in GCP. This mechanism is maintained by GCP, and used by our package.
-- Makefile -> Our makefile used to create new images. The three components (deployer, redis, op-scim-bridge) get built seperately and pushed to distinct subdirectories of the op-scim-bridge GCP image.
+- Makefile -> Our makefile used to create new images. The three components (deployer, redis, op-scim-bridge) get built separately and pushed to distinct subdirectories of the op-scim-bridge GCP image.
 - schema.yaml -> Defines the top level variables that will be queried in the marketplace deployer.
 
 ## Building a New Image
 
-Using the makefile, one can create a push a new image to GCR. To do so, one must declare environment variables:
+Using the makefile, one can create a push a new image to the Google Container Registry (GCR). To do so, one must declare environment variables:
 
 - REGISTRY - The google cloud registry we are building for
 - PUBLIC_TAG of the SCIM Bridge we are building off of.
@@ -65,15 +65,15 @@ PUBLIC_TAG=1.3.0-2 TAG=test-vendoring make app/build
 
 `mpdev` is a command line tool from the marketplace tool which allows one to build, install, and verify a GCP Marketplace application.
 
-A pre-requisite to using mpdev is an existing `kubectl` installation with access to your GCP kubernetes cluster.
+A pre-requisite to using mpdev is an existing `kubectl` installation with access to your GCP Kubernetes cluster.
 
 Any reference to `--deployer=gcr.op/op-scim-bridge/op-scim-bridge/deployer:TAG` is referencing the constructed docker image. If not present locally, this will be pulled from the Google Container Registry.
 
-Tags are updated regularily and may vary. The `latest` tag is not always updated, so be sure to check dates when pulling. For illistrative purposes, these examples will use the `latest` tag.
+Tags are updated regularly and may vary. The `latest` tag is not always updated, so be sure to check dates when pulling. For illustrative purposes, these examples will use the `latest` tag.
 
 ### Tool Installation
 
-The installation process concludes with a PATHable binary somewhere on your marchine through running a docker image locally. Feel free to customise to your setup, but this was what worked for me:
+The installation process concludes with a PATH-able binary somewhere on your machine through running a docker image locally. Feel free to customise to your setup, but this was what worked for me:
 
 ```
 BIN_FILE="/usr/local/bin/mpdev"
@@ -81,15 +81,15 @@ BIN_FILE="/usr/local/bin/mpdev"
 docker run gcr.io/cloud-marketplace-tools/k8s/dev cat /scripts/dev > "$BIN_FILE"
 ```
 Two notes:
-    - `/usr/local/bin/*` was already PATHable for me
-    - The use of the `BIN_FILE` seemed neccessary as otherwise the docker run did not output correctly
+    - `/usr/local/bin/*` was already PATH-able for me
+    - The use of the `BIN_FILE` seemed necessary as otherwise the docker run did not output correctly
 
 
 You can validate your installation by running `mpdev doctor`
 
 ### mpdev install
 
-It is now possible to use mpdev to install our application on your kubernetes cluster on GCP. This allows you to test our application outside of the marketplace.
+It is now possible to use mpdev to install our application on your Kubernetes cluster on GCP. This allows you to test our application outside of the marketplace.
 
 As defined in [schema.yaml](./op-scim-bridge/schema.yaml) our application requires three arguments: `APP_INSTANCE_NAME`, `NAMESPACE`, and `OP_ACCOUNT_DOMAIN`. These parallel the values chosen in the user interface when deploying from the marketplace. This example uses `opscim.b5test.com`, but please replace that with your testing account, as otherwise your bridge will not allow the authentication.
 
@@ -99,6 +99,7 @@ mpdev install --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:latest --
 Once this process completes, you can examine your new SCIM Bridge on GCP using kubectl or via the GCP Console in the browser.
 
 ### mpdev verify
+
 
 mpdev verify runs the verification test image created from the `apptest` folder. This is set at a deployer tag. Run verification like so:
 

--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ Using the makefile, one can create a push a new image to GCR. To do so, one must
 - TAG to put on GCP. When releasing, these should mirror the PUBLIC_TAG
 
 ```
-REGISTRY=gcr.io/op-scim-bridge PUBLIC_TAG=1.3.0-2 TAG=deptest-1 make app/build?
+PUBLIC_TAG=1.3.0-2 TAG=1.3.0-2 make app/build
+```
+
+Alternatively, to build a testing build, one may specify a testing tag
+
+```
+PUBLIC_TAG=1.3.0-2 TAG=test-vendoring make app/build
 ```
 
 ## MPDev

--- a/README.md
+++ b/README.md
@@ -1,11 +1,118 @@
-op-scim on gcp
+# 1Password SCIM Bridge (op-scim) on GCP
 
-# Git submodules
+op-scim-gcp-marketplace is the bundling of the 1Password SCIM Bridge into a format suitable for the GCP Marketplace. The application can be found here:
+
+Generally this package describes a chart which wraps the op-scim docker image and deploys it as a service on a GCP Kubernetes Cluster alongside a redis service.
+
+To work with this deployment bundle, a developer requires use of the `mpdev` development tool from GCP. Installation and usage instructions are detailed below.
+
+## Package Structure
+
+```
+.
+├── op-scim-bridge
+│   ├── apptest
+│   │   └── deployer
+│   │       ├── op-scim-bridge
+│   │       │   ├── templates
+│   │       │   │   └── tester.yaml
+│   │       │   └── values.yaml
+│   │       └── schema.yaml
+│   ├── chart
+│   │   └── op-scim
+│   │       ├── Chart.yaml
+│   │       ├── README.md
+│   │       ├── templates
+│   │       │   ├── application.yaml
+│   │       │   ├── op-scim.yaml
+│   │       │   └── redis.yaml
+│   │       └── values.yaml
+│   ├── deployer
+│   │   └── Dockerfile
+│   ├── Makefile
+│   └── schema.yaml
+├── README.md
+└── vendor
+```
+The top level of this package has three items: this README, vendored marketplace-tools, and the op-scim-bridge GCP package.
+
+The op-scim-bridge package is fruther broken down into five components:
+- apptest -> Instructions for building the verification test image
+- chart -> The main chart (kubernetes package) for building and running the SCIM Bridge. More information can be found in [op-scim-bridge/chart/op-scim/README.md](./op-scim-bridge/chart/op-scim/README.md)
+- deployer -> The GCP deployer which creates and runs the chart in GCP. This mechanism is maintained by GCP, and used by our package.
+- Makefile -> Our makefile used to create new images. The three components (deployer, redis, op-scim-bridge) get built seperately and pushed to distinct subdirectories of the op-scim-bridge GCP image.
+- schema.yaml -> Defines the top level variables that will be queried in the marketplace deployer.
+
+## Building a New Image
+
+Using the makefile, one can create a push a new image to GCR. To do so, one must declare environment variables:
+
+- REGISTRY - The google cloud registry we are building for
+- PUBLIC_TAG of the SCIM Bridge we are building off of.
+- TAG to put on GCP. When releasing, these should mirror the PUBLIC_TAG
+
+```
+REGISTRY=gcr.io/op-scim-bridge PUBLIC_TAG=1.3.0-2 TAG=deptest-1 make app/build?
+```
+
+## MPDev
+
+`mpdev` is a command line tool from the marketplace tool which allows one to build, install, and verify a GCP Marketplace application.
+
+A pre-requisite to using mpdev is an existing `kubectl` installation with access to your GCP kubernetes cluster.
+
+Any reference to `--deployer=gcr.op/op-scim-bridge/op-scim-bridge/deployer:TAG` is referencing the constructed docker image. If not present locally, this will be pulled from the Google Container Registry.
+
+Tags are updated regularily and may vary. The `latest` tag is not always updated, so be sure to check dates when pulling. For illistrative purposes, these examples will use the `latest` tag.
+
+### Tool Installation
+
+The installation process concludes with a PATHable binary somewhere on your marchine through running a docker image locally. Feel free to customise to your setup, but this was what worked for me:
+
+```
+BIN_FILE="/usr/local/bin/mpdev"
+
+docker run gcr.io/cloud-marketplace-tools/k8s/dev cat /scripts/dev > "$BIN_FILE"
+```
+Two notes:
+    - `/usr/local/bin/*` was already PATHable for me
+    - The use of the `BIN_FILE` seemed neccessary as otherwise the docker run did not output correctly
+
+
+You can validate your installation by running `mpdev doctor`
+
+### mpdev install
+
+It is now possible to use mpdev to install our application on your kubernetes cluster on GCP. This allows you to test our application outside of the marketplace.
+
+As defined in [schema.yaml](./op-scim-bridge/schema.yaml) our application requires three arguments: `APP_INSTANCE_NAME`, `NAMESPACE`, and `OP_ACCOUNT_DOMAIN`. These parallel the values chosen in the user interface when deploying from the marketplace. This example uses `opscim.b5test.com`, but please replace that with your testing account, as otherwise your bridge will not allow the authentication.
+
+```
+mpdev install --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:latest --parameters='{"APP_INSTANCE_NAME": "mpdev", "NAMESPACE": "default", "OP_ACCOUNT_DOMAIN": "opscim.b5test.com"}'
+```
+Once this process completes, you can examine your new SCIM Bridge on GCP using kubectl or via the GCP Console in the browser.
+
+### mpdev verify
+
+mpdev verify runs the verification test image created from the `apptest` folder. This is set at a deployer tag. Run verification like so:
+
+```
+mpdev verify --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:latest
+```
+
+The output is very long and rather hard to read, but all the components of what is happening are in there. Near the end you should see our simple `/ping` curl verification test happen. 
+
+### More
+
+A full installation guide can be found here: [GCP MPDev Reference](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools/blob/master/docs/mpdev-references.md)
+
+
+## Git Submodules
 
 This repository uses [GoogleCloudPlatform/marketplace-k8s-app-tools](https://github.com/GoogleCloudPlatform/marketplace-k8s-app-tools.git) submodule.
 Please run following commands to receive newest version of used modules.
 
-## Updating git submodules
+### Updating git submodules
 
 You can use make to make sure submodules
 are populated with proper code.
@@ -21,3 +128,6 @@ git submodule init
 git submodule sync --recursive
 git submodule update --recursive --init
 ```
+
+## Further information
+

--- a/op-scim-bridge/Makefile
+++ b/op-scim-bridge/Makefile
@@ -9,6 +9,8 @@ include ../vendor/marketplace-tools/var.Makefile
 TAG ?= latest
 $(info ---- TAG = $(TAG))
 
+REGISTRY="gcr.io/op-scim-bridge"
+
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/op-scim-bridge/deployer:$(TAG)
 NAME ?= op-scim-bridge
 APP_PARAMETERS ?= { \

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
@@ -1,0 +1,45 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-tester"
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}"
+  annotations:
+    helm.sh/hook: test-success
+spec:
+  containers:
+  - name: tester
+    image: "{{ .Values.tester.image }}"
+    volumeMounts:
+    - name: config-volume
+      mountPath: /tester
+    command: ["bash"]
+    args: ["/tester/run.sh"]
+  restartPolicy: Never
+  volumes:
+  - name: config-volume
+    configMap:
+      name: "{{ .Release.Name }}-test"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: "{{ .Release.Name }}-test"
+  labels:
+    app.kubernetes.io/name: "{{ .Release.Name }}"
+  annotations:
+    marketplace.cloud.google.com/verification: test
+data:
+  run.sh: |-
+    set -x
+    endpoint="http://{{ .Release.Name }}:{{ .Values.service.port }}"
+    echo GET $endpoint
+    http_status_code=$(curl -o /dev/null -s -w "%{http_code}\n" $endpoint)
+    echo "Expected http status code: 200"
+    echo "Actual http status code: $http_status_code"
+    if [[ "$http_status_code" == "200" ]]; then
+      echo SUCCESS
+    else
+      echo FAILURE
+      exit 1
+    fi

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
@@ -6,6 +6,7 @@ metadata:
     app.kubernetes.io/name: "{{ .Release.Name }}"
   annotations:
     helm.sh/hook: test-success
+    marketplace.cloud.google.com/verification: test
 spec:
   containers:
   - name: tester

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
@@ -13,7 +13,7 @@ spec:
     volumeMounts:
     - name: config-volume
       mountPath: /tester
-    command: ["bash"]
+    command: ["sh"]
     args: ["/tester/run.sh"]
   restartPolicy: Never
   volumes:
@@ -32,7 +32,7 @@ metadata:
 data:
   run.sh: |-
     set -x
-    endpoint="http://{{ .Release.Name }}:{{ .Values.service.port }}"
+    endpoint="http://{{ .Release.Name }}"
     echo GET $endpoint
     http_status_code=$(curl -o /dev/null -s -w "%{http_code}\n" $endpoint)
     echo "Expected http status code: 200"

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/templates/tester.yaml
@@ -32,10 +32,10 @@ metadata:
     marketplace.cloud.google.com/verification: test
 data:
   run.sh: |-
-    set -x
-    endpoint="http://{{ .Release.Name }}"
-    echo GET $endpoint
-    http_status_code=$(curl -o /dev/null -s -w "%{http_code}\n" $endpoint)
+    set -e
+    endpoint="http://{{ .Release.Name }}-bridge-svc"
+    echo "GET $endpoint/ping"
+    ping_response_code=$(curl --output /dev/null --silent --show-error --write-out "%{http_code}" "$endpoint/ping")
     echo "Expected http status code: 200"
     echo "Actual http status code: $http_status_code"
     if [[ "$http_status_code" == "200" ]]; then

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/values.yaml
@@ -1,0 +1,3 @@
+# This is an example showing that values in the app charts can be overwriten in test mode
+service:
+  port: 8080

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/values.yaml
@@ -1,1 +1,3 @@
 # This is an example showing that values in the app charts can be overwriten in test mode
+tester:
+  image: cosmintitei/bash-curl

--- a/op-scim-bridge/apptest/deployer/op-scim-bridge/values.yaml
+++ b/op-scim-bridge/apptest/deployer/op-scim-bridge/values.yaml
@@ -1,3 +1,1 @@
 # This is an example showing that values in the app charts can be overwriten in test mode
-service:
-  port: 8080

--- a/op-scim-bridge/apptest/deployer/schema.yaml
+++ b/op-scim-bridge/apptest/deployer/schema.yaml
@@ -1,0 +1,3 @@
+properties:
+  tester.image:
+    type: string

--- a/op-scim-bridge/chart/op-scim/README.md
+++ b/op-scim-bridge/chart/op-scim/README.md
@@ -18,3 +18,8 @@ op-scim
 
 
 Generally the Chart.yaml describes the chart as a whole, the values.yaml provides default configuration values, and the templates can be combined with the values to produce valid Kubernetes manifests.
+
+We have three templates: 
+- application.yaml -> Overarching application description. Includes high level user facing details such as description and maintainer links and a raw logo image. 
+- op-scim.yaml -> op-scim service description. Includes networking details, persistent volume connections, and startup arguments.
+- redis.yaml -> redis service description. Includes basic redis details and networking connection to the op-scim service.

--- a/op-scim-bridge/chart/op-scim/README.md
+++ b/op-scim-bridge/chart/op-scim/README.md
@@ -8,6 +8,7 @@ This is a chart, a Helm package for a Helm Chart Repository  which contains all 
 
 At the time of writing, the following is the package structure.
 
+```
 op-scim
 │       ├── Chart.yaml
 │       ├── templates
@@ -15,6 +16,7 @@ op-scim
 │       │   ├── op-scim.yaml
 │       │   └── redis.yaml
 │       └── values.yaml
+```
 
 
 Generally the Chart.yaml describes the chart as a whole, the values.yaml provides default configuration values, and the templates can be combined with the values to produce valid Kubernetes manifests.

--- a/op-scim-bridge/chart/op-scim/README.md
+++ b/op-scim-bridge/chart/op-scim/README.md
@@ -1,0 +1,20 @@
+# OP-SCIM Helm Chart
+
+This is a Helm Chart for the 1Password SCIM Bridge for use with Helm based deployers.
+
+## Helm Primer
+
+This is a chart, a Helm package for a Helm Chart Repository  which contains all the resource definitions necessary to run op-scim inside of a Kubernetes clister. More information on the structure of this package and the roles of the components can be found here: [https://helm.sh/docs/topics/charts/] (https://helm.sh/docs/topics/charts/)
+
+At the time of writing, the following is the package structure.
+
+op-scim
+│       ├── Chart.yaml
+│       ├── templates
+│       │   ├── application.yaml
+│       │   ├── op-scim.yaml
+│       │   └── redis.yaml
+│       └── values.yaml
+
+
+Generally the Chart.yaml describes the chart as a whole, the values.yaml provides default configuration values, and the templates can be combined with the values to produce valid Kubernetes manifests.

--- a/op-scim-bridge/chart/op-scim/README.md
+++ b/op-scim-bridge/chart/op-scim/README.md
@@ -4,7 +4,7 @@ This is a Helm Chart for the 1Password SCIM Bridge for use with Helm based deplo
 
 ## Helm Primer
 
-This is a chart, a Helm package for a Helm Chart Repository  which contains all the resource definitions necessary to run op-scim inside of a Kubernetes clister. More information on the structure of this package and the roles of the components can be found here: [https://helm.sh/docs/topics/charts/] (https://helm.sh/docs/topics/charts/)
+This is a chart, a Helm package for a Helm Chart Repository  which contains all the resource definitions necessary to run op-scim inside of a Kubernetes cluster. More information on the structure of this package and the roles of the components can be found here: [https://helm.sh/docs/topics/charts/] (https://helm.sh/docs/topics/charts/)
 
 At the time of writing, the following is the package structure.
 

--- a/op-scim-bridge/data-test/values.yaml
+++ b/op-scim-bridge/data-test/values.yaml
@@ -1,0 +1,2 @@
+tester:
+    image: "curlimages/curl:latest"

--- a/op-scim-bridge/data-test/values.yaml
+++ b/op-scim-bridge/data-test/values.yaml
@@ -1,2 +1,0 @@
-tester:
-    image: "curlimages/curl:latest"

--- a/op-scim-bridge/deployer/Dockerfile
+++ b/op-scim-bridge/deployer/Dockerfile
@@ -1,1 +1,16 @@
+FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm AS build
+
+ADD apptest/deployer/op-scim-bridge /tmp/test/chart
+RUN cd /tmp/test \
+    && tar -czvf /tmp/test/chart.tar.gz chart/
+
+ADD apptest/deployer/schema.yaml /tmp/apptest/schema.yaml
+RUN cat /tmp/apptest/schema.yaml \
+    | env -i "REGISTRY=$REGISTRY" "TAG=$TAG" envsubst \
+    > /tmp/apptest/schema.yaml.new \
+    && mv /tmp/apptest/schema.yaml.new /tmp/apptest/schema.yaml
+
 FROM gcr.io/cloud-marketplace-tools/k8s/deployer_helm/onbuild:0.9.10
+
+COPY --from=build /tmp/test/chart.tar.gz /data-test/chart/
+COPY --from=build /tmp/apptest/schema.yaml /data-test/


### PR DESCRIPTION
This MR includes changes for the GCP verification tests. Currently they just hit the /ping endpoint, looking for a 200 okay response. In the future we could expand this to running a more complex task, like running the e2e suite. However for now the ping endpoint suffices as it indicates the deployer was successful and has deployed the kubernetes cluster and has the appropriate running services. 