### PR TITLE
Version bump to 2.0.0 and update from now deprecated redis params

### DIFF
--- a/op-scim-bridge/chart/op-scim/Chart.yaml
+++ b/op-scim-bridge/chart/op-scim/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: op-scim-bridge
-version: 1.6.2
+version: 2.0.0
 description: The 1Password SCIM bridge
 keywords:
   - "azure active directory"
@@ -10,6 +10,6 @@ keywords:
 home: https://support.1password.com/scim
 maintainers: # (optional)
   - name: 1Password Platform Team
-    email: support+business@1password.com
+    email: support+scim@1password.com
 icon: https://1password.com/img/logo-v1.svg
-appVersion: v1.6.2
+appVersion: v2.0.0

--- a/op-scim-bridge/chart/op-scim/templates/op-scim.yaml
+++ b/op-scim-bridge/chart/op-scim/templates/op-scim.yaml
@@ -28,7 +28,6 @@ spec:
         image: {{ .Values.IMAGE_OP_SCIM }}
         imagePullPolicy: Always
         command: ["/op-scim/op-scim"]
-        args: ["--redis-host={{ .Values.APP_INSTANCE_NAME }}-redis-svc", "--session={{ .Values.scimUserHome }}/{{ .Values.scimsessionFile }}", "--port=8080"]
         env:
         - name: "update"
           value: "1"
@@ -36,6 +35,12 @@ spec:
           value: {{ .Values.OP_ACCOUNT_DOMAIN }}
         - name: OP_ONE_CLICK
           value: "true"
+        - name: OP_REDIS_URL
+          value: "redis://{{ .Values.APP_INSTANCE_NAME }}-redis-svc:6379"
+        - name: OP_PORT
+          value: "8080"
+        - name: OP_SESSION
+          value: "{{ .Values.scimUserHome }}/{{ .Values.scimsessionFile }}"
         ports:
         - containerPort: 8080
         - containerPort: 8443

--- a/op-scim-bridge/chart/op-scim/values.yaml
+++ b/op-scim-bridge/chart/op-scim/values.yaml
@@ -2,4 +2,4 @@ scimsessionFile: scimsession
 scimUserID: 999
 scimUserName: scimuser
 scimUserHome: /home/scimuser
-scimVersion: 1.6.2
+scimVersion: 2.0.0


### PR DESCRIPTION
I also updated the support email to the new `support+scim` version. 