### PR TITLE
Set resource requests and limits for op-scim-bridge and op-scim-redis

### DIFF
--- a/op-scim-bridge/chart/op-scim-bridge/templates/op-scim-deployment.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge/templates/op-scim-deployment.yaml
@@ -34,6 +34,13 @@ spec:
         image: {{ .Values.bridge.image.repository }}:{{ .Values.bridge.image.tag }}
         imagePullPolicy: Always
         command: ["/op-scim/op-scim"]
+        resources:
+          requests:
+            cpu: 125m
+            memory: 256M
+          limits:
+            cpu: 250m
+            memory: 512M
         env:
         - name: "OP_PORT"
           value: "8080"

--- a/op-scim-bridge/chart/op-scim-bridge/templates/redis-deployment.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge/templates/redis-deployment.yaml
@@ -18,5 +18,15 @@ spec:
       - name: op-scim-redis
         image: {{ .Values.redis.image.repository }}:{{ .Values.redis.image.tag }}
         imagePullPolicy: Always
+        resources:
+          requests:
+            cpu: 125m
+            memory: 256M
+          limits:
+            cpu: 250m
+            memory: 512M
+        env:
+        - name: "REDIS_ARGS"
+          value: - "--maxmemory 256mb --maxmemory-policy volatile-lru"
         ports:
         - containerPort: 6379

--- a/op-scim-bridge/chart/op-scim-bridge/templates/redis-deployment.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge/templates/redis-deployment.yaml
@@ -27,6 +27,6 @@ spec:
             memory: 512M
         env:
         - name: "REDIS_ARGS"
-          value: - "--maxmemory 256mb --maxmemory-policy volatile-lru"
+          value: "--maxmemory 256mb --maxmemory-policy volatile-lru"
         ports:
         - containerPort: 6379


### PR DESCRIPTION
In this PR we set resource requests and limits for the SCIM bridge and Redis application pods.

We also set a max memory limit for Redis before the Redis server will start evicting keys based on the selected policy.

Related to https://github.com/1Password/op-scim-helm/pull/54.