### PR TITLE
Fix deployer clean up crash

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,12 +107,11 @@ As defined in [schema.yaml](./op-scim-bridge/schema.yaml) our application requir
 - `name`
 - `namespace`
 - `accountDomain`
-- `scim.serviceAccount`
  
 These parallel the values chosen in the user interface when deploying from the Marketplace.
 
 ```bash
-mpdev install --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:latest --parameters='{"name": "mpdev", "namespace": "default", "accountDomain": "testing.1password.com", "scim.serviceAccount": "op-scim-bridge-deployer-sa" }'
+mpdev install --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:latest --parameters='{"name": "mpdev", "namespace": "default", "accountDomain": "testing.1password.com" }'
 ```
 
 Once this process completes, you can examine your new SCIM Bridge on GCP using kubectl or via the GCP Console in the browser.

--- a/op-scim-bridge/chart/op-scim-bridge-mp/templates/application.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge-mp/templates/application.yaml
@@ -46,3 +46,7 @@ spec:
     kind: CronJob
   - group: v1
     kind: ServiceAccount
+  - group: v1
+    kind: Role
+  - group: v1
+    kind: RoleBinding

--- a/op-scim-bridge/chart/op-scim-bridge-mp/templates/deployer-cleanup.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge-mp/templates/deployer-cleanup.yaml
@@ -69,7 +69,7 @@ spec:
           - name: config-volume
             configMap:
               name: "{{ .Values.name }}-cleanup-script"
----
+--- # clean up job script definition
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/op-scim-bridge/chart/op-scim-bridge-mp/templates/deployer-cleanup.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge-mp/templates/deployer-cleanup.yaml
@@ -1,3 +1,37 @@
+--- # service account for cleanup jon
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: "{{ .Values.name }}-cleanup-sa"
+  namespace: {{ .Values.namespace }}
+--- # permissions for cleanup job
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: "{{ .Values.name }}-cleanup-role"
+  namespace: {{ .Values.namespace }}
+rules:
+  - apiGroups:
+      - "" # "" indicates the core API group
+      - batch
+    resources:
+      - jobs
+    verbs: ["get", "list", "delete"]
+--- # add permissions to service account
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: "{{ .Values.name }}-cleanup-rolebinding"
+  namespace: {{ .Values.namespace }} 
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: "{{ .Values.name }}-cleanup-role"
+subjects:
+- namespace: {{ .Values.namespace }} 
+  kind: ServiceAccount
+  name: "{{ .Values.name }}-cleanup-sa"
+--- # clean up job definition
 apiVersion: batch/v1beta1
 kind: CronJob
 metadata:
@@ -7,16 +41,20 @@ metadata:
     app.kubernetes.io/name: {{ .Values.name }}
     app.kubernetes.io/component: cleanup
 spec:
-  schedule: "*/1 * * * *" # once a minute
-  successfulJobsHistoryLimit: 0
+  schedule: "*/10 * * * *" # every 10 minutes
+  successfulJobsHistoryLimit: 1
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:
+      parallelism: 1 # how many pods will be instantiated at once
+      completions: 1 # how many containers of the job are instantiated one after the other (sequentially) inside the pod
+      backoffLimit: 1 # maximum pod restarts in case of failure
+      activeDeadlineSeconds: 300 # limit the time for which a Job can continue to run; 5 minutes
       template:
         metadata:
           labels: *CronLabels
         spec:
-          serviceAccountName: {{ .Values.scim.serviceAccount }}
+          serviceAccountName: "{{ .Values.name }}-cleanup-sa"
           containers:
           - name: kubectl-runner
             image: bitnami/kubectl
@@ -26,6 +64,7 @@ spec:
             command: ["/bin/bash"]
             args: ["/cleanup/delete-deployer.sh"]
           restartPolicy: Never
+          terminationGracePeriodSeconds: 30
           volumes:
           - name: config-volume
             configMap:
@@ -40,16 +79,25 @@ metadata:
     app.kubernetes.io/name: "{{ .Values.name }}"
     app.kubernetes.io/component: cleanup-script
 data:
-    delete-deployer.sh: |-
-      set -e
-      deployer_job=$(kubectl get jobs -n {{ .Values.namespace }} | awk '$1 ~ /{{ .Values.name }}-deployer/ && $2 ~ /1.*1/ { print $1 }' 2>/dev/null) # determine if the deployer is running
-      completed_at=$(kubectl -n {{ .Values.namespace }} describe job $deployer_job | grep 'Completed At' 2>/dev/null)
-      echo "checking for deployer"
-      if [[ "$completed_at" ]]; then
-        sleep 60 # wait for mpdev to finish verifying
-        echo "deployer detected, deleting"
-        kubectl delete jobs -n {{ .Values.namespace }} $deployer_job 2>/dev/null; # delete the job with the correct name
-      else
-        echo "deployer not completed, skipping"
-      fi
+  delete-deployer.sh: |-
+    set -e
+    
+    deployer_job=$(kubectl get jobs -n {{ .Values.namespace }} | awk -v name={{ .Values.name }}-deployer '$1 ~ name && $2 ~ /1.*1/ { print $1 }' 2>/dev/null)
+    echo "checking for deployer job"
+    if [[ "$deployer_job" ]]; then
+      echo "deployer job found: $deployer_job"
+    else
+      echo "no deployer job found, skipping"
       exit 0
+    fi
+
+    completed_at=$(kubectl -n {{ .Values.namespace }} describe job $deployer_job | grep 'Completed At' 2>/dev/null)
+    echo "checking if deployer job completed"
+    if [[ "$completed_at" ]]; then
+      echo "deployer job completed, deleting"
+      kubectl delete jobs -n {{ .Values.namespace }} $deployer_job
+    else
+      echo "deployer job not completed, skipping"
+    fi
+
+    exit 0

--- a/op-scim-bridge/chart/op-scim-bridge-mp/templates/deployer-cleanup.yaml
+++ b/op-scim-bridge/chart/op-scim-bridge-mp/templates/deployer-cleanup.yaml
@@ -42,7 +42,7 @@ metadata:
     app.kubernetes.io/component: cleanup
 spec:
   schedule: "*/10 * * * *" # every 10 minutes
-  successfulJobsHistoryLimit: 1
+  successfulJobsHistoryLimit: 0 # can be set to 1 for debugging to see logs of successful jobs
   failedJobsHistoryLimit: 1
   jobTemplate:
     spec:

--- a/op-scim-bridge/schema.yaml
+++ b/op-scim-bridge/schema.yaml
@@ -50,23 +50,8 @@ properties:
       "Your 1Password sign-in address. For example: example.1password.com"
     type: string
     default: example.1password.com
-  scim.serviceAccount:
-    type: string
-    title: Kubernetes Service Account
-    x-google-marketplace:
-      type: SERVICE_ACCOUNT
-      serviceAccount:
-        description: Service account to manage your Kubernetes cluster
-        roles:
-          - type: ClusterRole
-            rulesType: CUSTOM
-            rules:
-              - apiGroups: ["", "batch"]
-                resources: ["jobs"]
-                verbs: ["get", "list", "delete"]
 
 required:
   - name
   - namespace
   - accountDomain
-  - scim.serviceAccount


### PR DESCRIPTION
Note that this PR is based off of #51, and should only be reviewed/merged _after_ #51 is merged. The _draft_ status will be removed once #51 is reviewed and merged.

In this PR we fix the deployer cleanup crash issue described in #52. The root cause of the issue is that the service account used was the one associated with the deployer, but this service account is not guaranteed to be available once the deployer is no longer needed.

The change was to let the cleanup script own the resources it needs to perform it's job. This includes:
- a service account
- a role
- a role binding
- a cron job
- a config map

This means we are no longer dependent on the `scim.serviceAccount` value being set during the configuration of the market place app. I updated the schema and documentation to reflect that.

To test:
1. Make sure you are in the `op-scim-bridge` folder (same as `Makefile`)
2. Create an image using a test tag: `REGISTRY="gcr.io/op-scim-bridge" TAG=t<test-tag-name> make app/build`
3. Verify the test deployer: `TAG=<test-tag-name> make app/test`
4. Ensure that the verify succeeds
6. Install the test deployer on a GCP cluster:
     ```
    mpdev install --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:<test-tag-name> --parameters='{"name": "op-scim-bridge", "namespace": "op-scim-bridge", "accountDomain": "testing.1password.com" }'
    ```
    Note that we are _not_ setting `scim.serviceAccount` value.
7. Ensure that the install succeeds and that the application (and dependencies) are running without error.
8. Wait _about_ 10 minutes for the cleanup job to run and confirm that the deployer pod is cleaned up, i.e. the following command should not yield any pods with the name `<namespace>-deployer-*`:
    ```
    kubectl get pods --namespace=<namespace> -o wide
    ```
    Note that there will be a single pod with the name `<namespace>-cleanup-*` for the successful cleanup job run (in the `Completed` state).