### PR TITLE
Push dependency images when deployer is built

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Updating the version of the SCIM bridge involves a few steps that are described 
 
 See [Updating the SCIM bridge version](./op-scim-bridge/chart/op-scim-bridge-mp/README.md#updating-the-scim-bridge-version) for details.
 
+Note that if there is a major version change of the bundled dependencies (i.e. the SCIM bridge or bitnami/redis), then we should also update the major version number of the following corresponding variables in the [op-scim-bridge/push-dep-image-tags.sh](op-scim-bridge/push-dep-image-tags.sh) script:
+- `OP_SCIM_BRIDGE_HELM_VERSION`
+- `BITNAMI_REDIS_HELM_VERSION`
+
 ## Building a New Image
 
 Using the makefile, one can create a push a new image to the Google Container Registry (GCR). To do so, one must declare environment variables:

--- a/op-scim-bridge/Makefile
+++ b/op-scim-bridge/Makefile
@@ -4,7 +4,6 @@ TAG ?= latest
 include ../tools/gcloud.Makefile
 include ../tools/var.Makefile
 
-APP_IMAGE ?= $(REGISTRY)/op-scim-bridge:$(TAG)
 APP_DEPLOYER_IMAGE ?= $(REGISTRY)/op-scim-bridge/deployer:$(TAG)
 APP_GCS_PATH ?= $(GCS_URL)/$(APP_ID)/$(TAG)
 CHART_NAME ?= op-scim-bridge
@@ -17,10 +16,11 @@ APP_TEST_PARAMETERS ?= {}
 
 include ../tools/app.Makefile
 
-app/build:: .build/op-scim/deployer
-
-.build/op-scim: | .build
-	mkdir -p "$@"
+app/build:: .build/check/docker .build/op-scim/deployer .build/op-scim/deps
+	@echo "\nimage tags pushed:"
+	@echo "deployer: $(APP_DEPLOYER_IMAGE)"
+	@echo "scim bridge: ${REGISTRY}/op-scim-bridge:${TAG}"
+	@echo "redis: ${REGISTRY}/op-scim-bridge/redis:${TAG}"
 
 .build/op-scim/deployer: .build/var/APP_DEPLOYER_IMAGE \
 						 $(shell find chart -type f) \
@@ -41,6 +41,12 @@ app/build:: .build/op-scim/deployer
 		.
 	docker push "$(APP_DEPLOYER_IMAGE)"
 	@touch "$@"
+
+.build/check/docker:
+	./check-docker.sh
+
+.build/op-scim/deps:
+	./push-dep-image-tags.sh
 
 app/test:
 	mpdev /scripts/verify --deployer=gcr.io/op-scim-bridge/op-scim-bridge/deployer:${TAG}

--- a/op-scim-bridge/check-docker.sh
+++ b/op-scim-bridge/check-docker.sh
@@ -1,0 +1,11 @@
+#! /bin/sh
+
+if ! command -v docker &> /dev/null; then
+  echo "docker could not be found"
+  exit
+fi
+
+if (! docker stats --no-stream &> /dev/null); then
+  echo "docker daemon not running; ensure docker is running"
+  exit
+fi

--- a/op-scim-bridge/push-dep-image-tags.sh
+++ b/op-scim-bridge/push-dep-image-tags.sh
@@ -1,0 +1,57 @@
+#! /bin/sh
+
+if ! command -v helm &> /dev/null
+then
+  echo "helm could not be found"
+  exit
+fi
+
+if ! command -v jq &> /dev/null
+then
+  echo "jq could not be found"
+  exit
+fi
+
+echo "adding 1password Helm repo"
+helm repo add 1password https://1password.github.io/op-scim-helm
+helm repo update 1password
+
+echo "adding bitnami Helm repo"
+helm repo add bitnami https://charts.bitnami.com/bitnami
+helm repo update bitnami
+
+# OP_SCIM_BRIDGE_HELM_VERSION should the "op-scim-bridge" dependency verion in 
+# https://github.com/1Password/op-scim-gcp-marketplace/blob/master/op-scim-bridge/chart/op-scim-bridge-mp/Chart.yaml
+if [[ -z "${OP_SCIM_BRIDGE_HELM_VERSION}" ]]; then
+  OP_SCIM_BRIDGE_HELM_VERSION="^2"
+  echo "OP_SCIM_BRIDGE_HELM_VERSION not set; using default ${OP_SCIM_BRIDGE_HELM_VERSION}"
+fi
+
+OP_SCIM_BRIDGE_REPO="1password/scim"
+OP_SCIM_BRIDGE_TAG=$(helm search repo 1password/op-scim-bridge --version ${OP_SCIM_BRIDGE_HELM_VERSION} -o json | jq -r '.[] | .app_version')
+OP_SCIM_BRIDGE_IMAGE=${OP_SCIM_BRIDGE_REPO}:${OP_SCIM_BRIDGE_TAG}
+echo "scim bridge image: ${OP_SCIM_BRIDGE_IMAGE}"
+
+# BITNAMI_REDIS_HELM_VERSION should match the "redis" dependency verion in 
+# https://github.com/1Password/op-scim-helm/blob/main/charts/op-scim-bridge/Chart.yaml
+if [[ -z "${BITNAMI_REDIS_HELM_VERSION}" ]]; then
+  BITNAMI_REDIS_HELM_VERSION="^16"
+  echo "BITNAMI_REDIS_HELM_VERSION not set; using default ${BITNAMI_REDIS_HELM_VERSION}"
+fi
+
+BITNAMI_REDIS_REPO="bitnami/redis"
+BITNAMI_REDIS_TAG=$(helm search repo bitnami/redis --version ${BITNAMI_REDIS_HELM_VERSION} -o json | jq -r '.[] | .app_version')
+BITNAMI_REDIS_IMAGE=${BITNAMI_REDIS_REPO}:${BITNAMI_REDIS_TAG}
+echo "redis image: ${BITNAMI_REDIS_IMAGE}"
+
+echo "pull docker images"
+docker pull ${OP_SCIM_BRIDGE_IMAGE}
+docker pull ${BITNAMI_REDIS_IMAGE}
+
+echo "tag docker images"
+docker tag ${OP_SCIM_BRIDGE_IMAGE} ${REGISTRY}/op-scim-bridge:${TAG}
+docker tag ${BITNAMI_REDIS_IMAGE} ${REGISTRY}/op-scim-bridge/redis:${TAG}
+
+echo "push docker images"
+docker push ${REGISTRY}/op-scim-bridge:${TAG}
+docker push ${REGISTRY}/op-scim-bridge/redis:${TAG}

--- a/op-scim-bridge/push-dep-image-tags.sh
+++ b/op-scim-bridge/push-dep-image-tags.sh
@@ -20,7 +20,7 @@ echo "adding bitnami Helm repo"
 helm repo add bitnami https://charts.bitnami.com/bitnami
 helm repo update bitnami
 
-# OP_SCIM_BRIDGE_HELM_VERSION should the "op-scim-bridge" dependency verion in 
+# OP_SCIM_BRIDGE_HELM_VERSION should the "op-scim-bridge" dependency version in 
 # https://github.com/1Password/op-scim-gcp-marketplace/blob/master/op-scim-bridge/chart/op-scim-bridge-mp/Chart.yaml
 if [[ -z "${OP_SCIM_BRIDGE_HELM_VERSION}" ]]; then
   OP_SCIM_BRIDGE_HELM_VERSION="^2"
@@ -32,7 +32,7 @@ OP_SCIM_BRIDGE_TAG=$(helm search repo 1password/op-scim-bridge --version ${OP_SC
 OP_SCIM_BRIDGE_IMAGE=${OP_SCIM_BRIDGE_REPO}:${OP_SCIM_BRIDGE_TAG}
 echo "scim bridge image: ${OP_SCIM_BRIDGE_IMAGE}"
 
-# BITNAMI_REDIS_HELM_VERSION should match the "redis" dependency verion in 
+# BITNAMI_REDIS_HELM_VERSION should match the "redis" dependency version in 
 # https://github.com/1Password/op-scim-helm/blob/main/charts/op-scim-bridge/Chart.yaml
 if [[ -z "${BITNAMI_REDIS_HELM_VERSION}" ]]; then
   BITNAMI_REDIS_HELM_VERSION="^16"


### PR DESCRIPTION
In this PR we add some automation to push the dependency images tags when we build the deployer image, specifically the `1password/scim` and `bitnami/redis` image. These images tags are used in the validation process when new versions of the deployer are submitted.

To test use the standard make commands with a test tag name, i.e.:
REGISTRY=gcr.io/op-scim-bridge TAG=<test-tag-name> make app/build

You will notice that there are several steps that happen after the deployer image is pushed. This is to get the SCIM bridge and redis images, tag them and push them up to the same registry.

The command will also output the images that were pushed, for example:
```
image tags pushed:
deployer: gcr.io/op-scim-bridge/op-scim-bridge/deployer:<test-tag-name>
scim bridge: gcr.io/op-scim-bridge/op-scim-bridge:<test-tag-name>
redis: gcr.io/op-scim-bridge/op-scim-bridge/redis:<test-tag-name>
```

The goal is to automatically get the correct versions of the SCIM bridge and redis that is actually deployed with the marketplace application. I chose the Helm charts (`1password/op-scim-bridge` and `bitnami/redis`) as the `appVersion` of these charts should be pretty close if not 100% accurate.

I also aimed to do this as part of the process we already do as part of a release.