### PR TITLE
Update debian12 image path

### DIFF
--- a/op-scim-bridge/deployer/Dockerfile
+++ b/op-scim-bridge/deployer/Dockerfile
@@ -1,5 +1,5 @@
 ARG MARKETPLACE_TOOLS_TAG
-FROM marketplace.gcr.io/google/debian12 AS build
+FROM gcr.io/cloud-marketplace/google/debian12 AS build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gettext


### PR DESCRIPTION
This PR updates debian12 image path it has been updated to gcr.io/cloud-marketplace/google/debian12 from marketplace.gcr.io/google/debian12

Reference:

https://console.cloud.google.com/artifacts/docker/cloud-marketplace/us/gcr.io/google%2Fdebian12/sha256:7b9512bd623326f1483b26c14a8faad086b870abfc717f2b770824b470bd6bd6;tab=install